### PR TITLE
feat: deferred client initialization

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -1,12 +1,13 @@
 {
-  "updateTime": "2020-02-29T19:14:13.934361Z",
+  "updateTime": "2020-03-05T23:03:38.966192Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "83c6f84035ee0f80eaa44d8b688a010461cc4080",
-        "internalRef": "297918498"
+        "sha": "f0b581b5bdf803e45201ecdb3688b60e381628a8",
+        "internalRef": "299181282",
+        "log": "f0b581b5bdf803e45201ecdb3688b60e381628a8\nfix: recommendationengine/v1beta1 update some comments\n\nPiperOrigin-RevId: 299181282\n\n10e9a0a833dc85ff8f05b2c67ebe5ac785fe04ff\nbuild: add generated BUILD file for Routes Preferred API\n\nPiperOrigin-RevId: 299164808\n\n86738c956a8238d7c77f729be78b0ed887a6c913\npublish v1p1beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299152383\n\n73d9f2ad4591de45c2e1f352bc99d70cbd2a6d95\npublish v1: update with absolute address in comments\n\nPiperOrigin-RevId: 299147194\n\nd2158f24cb77b0b0ccfe68af784c6a628705e3c6\npublish v1beta2: update with absolute address in comments\n\nPiperOrigin-RevId: 299147086\n\n7fca61292c11b4cd5b352cee1a50bf88819dd63b\npublish v1p2beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146903\n\n583b7321624736e2c490e328f4b1957335779295\npublish v1p3beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146674\n\n638253bf86d1ce1c314108a089b7351440c2f0bf\nfix: add java_multiple_files option for automl text_sentiment.proto\n\nPiperOrigin-RevId: 298971070\n\n373d655703bf914fb8b0b1cc4071d772bac0e0d1\nUpdate Recs AI Beta public bazel file\n\nPiperOrigin-RevId: 298961623\n\ndcc5d00fc8a8d8b56f16194d7c682027b2c66a3b\nfix: add java_multiple_files option for automl classification.proto\n\nPiperOrigin-RevId: 298953301\n\na3f791827266f3496a6a5201d58adc4bb265c2a3\nchore: automl/v1 publish annotations and retry config\n\nPiperOrigin-RevId: 298942178\n\n01c681586d8d6dbd60155289b587aee678530bd9\nMark return_immediately in PullRequest deprecated.\n\nPiperOrigin-RevId: 298893281\n\nc9f5e9c4bfed54bbd09227e990e7bded5f90f31c\nRemove out of date documentation for predicate support on the Storage API\n\nPiperOrigin-RevId: 298883309\n\nfd5b3b8238d783b04692a113ffe07c0363f5de0f\ngenerate webrisk v1 proto\n\nPiperOrigin-RevId: 298847934\n\n541b1ded4abadcc38e8178680b0677f65594ea6f\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 298686266\n\nc0d171acecb4f5b0bfd2c4ca34fc54716574e300\n  Updated to include the Notification v1 API.\n\nPiperOrigin-RevId: 298652775\n\n2346a9186c0bff2c9cc439f2459d558068637e05\nAdd Service Directory v1beta1 protos and configs\n\nPiperOrigin-RevId: 298625638\n\na78ed801b82a5c6d9c5368e24b1412212e541bb7\nPublishing v3 protos and configs.\n\nPiperOrigin-RevId: 298607357\n\n4a180bfff8a21645b3a935c2756e8d6ab18a74e0\nautoml/v1beta1 publish proto updates\n\nPiperOrigin-RevId: 298484782\n\n6de6e938b7df1cd62396563a067334abeedb9676\nchore: use the latest gapic-generator and protoc-java-resource-name-plugin in Bazel workspace.\n\nPiperOrigin-RevId: 298474513\n\n244ab2b83a82076a1fa7be63b7e0671af73f5c02\nAdds service config definition for bigqueryreservation v1\n\nPiperOrigin-RevId: 298455048\n\n"
       }
     },
     {

--- a/test/gapic-cloud_build-v1.ts
+++ b/test/gapic-cloud_build-v1.ts
@@ -102,12 +102,30 @@ describe('v1.CloudBuildClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new cloudbuildModule.v1.CloudBuildClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.cloudBuildStub, undefined);
+    await client.initialize();
+    assert(client.cloudBuildStub);
+  });
+  it('has close method', () => {
+    const client = new cloudbuildModule.v1.CloudBuildClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getBuild', () => {
     it('invokes getBuild without error', done => {
       const client = new cloudbuildModule.v1.CloudBuildClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IGetBuildRequest = {};
       // Mock response
@@ -130,6 +148,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IGetBuildRequest = {};
       // Mock response
@@ -154,6 +174,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.ICancelBuildRequest = {};
       // Mock response
@@ -176,6 +198,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.ICancelBuildRequest = {};
       // Mock response
@@ -200,6 +224,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.ICreateBuildTriggerRequest = {};
       // Mock response
@@ -222,6 +248,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.ICreateBuildTriggerRequest = {};
       // Mock response
@@ -246,6 +274,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IGetBuildTriggerRequest = {};
       // Mock response
@@ -268,6 +298,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IGetBuildTriggerRequest = {};
       // Mock response
@@ -292,6 +324,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IDeleteBuildTriggerRequest = {};
       // Mock response
@@ -314,6 +348,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IDeleteBuildTriggerRequest = {};
       // Mock response
@@ -338,6 +374,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IUpdateBuildTriggerRequest = {};
       // Mock response
@@ -360,6 +398,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IUpdateBuildTriggerRequest = {};
       // Mock response
@@ -384,6 +424,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.ICreateWorkerPoolRequest = {};
       // Mock response
@@ -406,6 +448,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.ICreateWorkerPoolRequest = {};
       // Mock response
@@ -430,6 +474,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IGetWorkerPoolRequest = {};
       // Mock response
@@ -452,6 +498,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IGetWorkerPoolRequest = {};
       // Mock response
@@ -476,6 +524,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IDeleteWorkerPoolRequest = {};
       // Mock response
@@ -498,6 +548,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IDeleteWorkerPoolRequest = {};
       // Mock response
@@ -522,6 +574,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IUpdateWorkerPoolRequest = {};
       // Mock response
@@ -544,6 +598,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IUpdateWorkerPoolRequest = {};
       // Mock response
@@ -568,6 +624,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IListWorkerPoolsRequest = {};
       // Mock response
@@ -590,6 +648,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IListWorkerPoolsRequest = {};
       // Mock response
@@ -614,6 +674,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.ICreateBuildRequest = {};
       // Mock response
@@ -643,6 +705,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.ICreateBuildRequest = {};
       // Mock response
@@ -675,6 +739,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IRetryBuildRequest = {};
       // Mock response
@@ -704,6 +770,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IRetryBuildRequest = {};
       // Mock response
@@ -736,6 +804,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IRunBuildTriggerRequest = {};
       // Mock response
@@ -765,6 +835,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IRunBuildTriggerRequest = {};
       // Mock response
@@ -797,6 +869,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IListBuildsRequest = {};
       // Mock response
@@ -823,6 +897,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IListBuildsRequest = {};
       // Mock response
@@ -854,6 +930,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IListBuildTriggersRequest = {};
       // Mock response
@@ -880,6 +958,8 @@ describe('v1.CloudBuildClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.devtools.cloudbuild.v1.IListBuildTriggersRequest = {};
       // Mock response


### PR DESCRIPTION
This PR includes changes from https://github.com/googleapis/gapic-generator-typescript/pull/317
that will move the asynchronous initialization and authentication from the client constructor
to an `initialize()` method. This method will be automatically called when the first RPC call
is performed.

The client library usage has not changed, there is no need to update any code.

If you want to make sure the client is authenticated _before_ the first RPC call, you can do
```js
await client.initialize();
```
manually before calling any client method.