### PR TITLE
feat: check status of long running operation by its name

### DIFF
--- a/src/v1/cloud_build_client.ts
+++ b/src/v1/cloud_build_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './cloud_build_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1462,6 +1462,42 @@ export class CloudBuildClient {
     this.initialize();
     return this.innerApiCalls.createBuild(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the createBuild() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkCreateBuildProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkCreateBuildProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.devtools.cloudbuild.v1.Build,
+      protos.google.devtools.cloudbuild.v1.BuildOperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.createBuild,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.devtools.cloudbuild.v1.Build,
+      protos.google.devtools.cloudbuild.v1.BuildOperationMetadata
+    >;
+  }
   retryBuild(
     request: protos.google.devtools.cloudbuild.v1.IRetryBuildRequest,
     options?: gax.CallOptions
@@ -1588,6 +1624,42 @@ export class CloudBuildClient {
     this.initialize();
     return this.innerApiCalls.retryBuild(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the retryBuild() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkRetryBuildProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkRetryBuildProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.devtools.cloudbuild.v1.Build,
+      protos.google.devtools.cloudbuild.v1.BuildOperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.retryBuild,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.devtools.cloudbuild.v1.Build,
+      protos.google.devtools.cloudbuild.v1.BuildOperationMetadata
+    >;
+  }
   runBuildTrigger(
     request: protos.google.devtools.cloudbuild.v1.IRunBuildTriggerRequest,
     options?: gax.CallOptions
@@ -1689,6 +1761,42 @@ export class CloudBuildClient {
     });
     this.initialize();
     return this.innerApiCalls.runBuildTrigger(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the runBuildTrigger() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkRunBuildTriggerProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkRunBuildTriggerProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.devtools.cloudbuild.v1.Build,
+      protos.google.devtools.cloudbuild.v1.BuildOperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.runBuildTrigger,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.devtools.cloudbuild.v1.Build,
+      protos.google.devtools.cloudbuild.v1.BuildOperationMetadata
+    >;
   }
   listBuilds(
     request: protos.google.devtools.cloudbuild.v1.IListBuildsRequest,

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-cloudbuild.git",
-        "sha": "eaa52923d28e6f61c425f7d40a29a15305de9c86"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "42ee97c1b93a0e3759bbba3013da309f670a90ab",
-        "internalRef": "307114445"
+        "remote": "git@github.com:googleapis/nodejs-cloudbuild.git",
+        "sha": "7b55f19b90423b4e1ab4db41707ad26b036cb935"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/test/gapic_cloud_build_v1.ts
+++ b/test/gapic_cloud_build_v1.ts
@@ -25,7 +25,7 @@ import * as cloudbuildModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -326,9 +326,7 @@ describe('v1.CloudBuildClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getBuild = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getBuild(request);
-      }, expectedError);
+      await assert.rejects(client.getBuild(request), expectedError);
       assert(
         (client.innerApiCalls.getBuild as SinonStub)
           .getCall(0)
@@ -440,9 +438,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.cancelBuild(request);
-      }, expectedError);
+      await assert.rejects(client.cancelBuild(request), expectedError);
       assert(
         (client.innerApiCalls.cancelBuild as SinonStub)
           .getCall(0)
@@ -556,9 +552,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createBuildTrigger(request);
-      }, expectedError);
+      await assert.rejects(client.createBuildTrigger(request), expectedError);
       assert(
         (client.innerApiCalls.createBuildTrigger as SinonStub)
           .getCall(0)
@@ -670,9 +664,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getBuildTrigger(request);
-      }, expectedError);
+      await assert.rejects(client.getBuildTrigger(request), expectedError);
       assert(
         (client.innerApiCalls.getBuildTrigger as SinonStub)
           .getCall(0)
@@ -786,9 +778,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteBuildTrigger(request);
-      }, expectedError);
+      await assert.rejects(client.deleteBuildTrigger(request), expectedError);
       assert(
         (client.innerApiCalls.deleteBuildTrigger as SinonStub)
           .getCall(0)
@@ -902,9 +892,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateBuildTrigger(request);
-      }, expectedError);
+      await assert.rejects(client.updateBuildTrigger(request), expectedError);
       assert(
         (client.innerApiCalls.updateBuildTrigger as SinonStub)
           .getCall(0)
@@ -992,9 +980,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createWorkerPool(request);
-      }, expectedError);
+      await assert.rejects(client.createWorkerPool(request), expectedError);
       assert(
         (client.innerApiCalls.createWorkerPool as SinonStub)
           .getCall(0)
@@ -1082,9 +1068,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getWorkerPool(request);
-      }, expectedError);
+      await assert.rejects(client.getWorkerPool(request), expectedError);
       assert(
         (client.innerApiCalls.getWorkerPool as SinonStub)
           .getCall(0)
@@ -1172,9 +1156,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteWorkerPool(request);
-      }, expectedError);
+      await assert.rejects(client.deleteWorkerPool(request), expectedError);
       assert(
         (client.innerApiCalls.deleteWorkerPool as SinonStub)
           .getCall(0)
@@ -1262,9 +1244,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateWorkerPool(request);
-      }, expectedError);
+      await assert.rejects(client.updateWorkerPool(request), expectedError);
       assert(
         (client.innerApiCalls.updateWorkerPool as SinonStub)
           .getCall(0)
@@ -1352,9 +1332,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listWorkerPools(request);
-      }, expectedError);
+      await assert.rejects(client.listWorkerPools(request), expectedError);
       assert(
         (client.innerApiCalls.listWorkerPools as SinonStub)
           .getCall(0)
@@ -1474,9 +1452,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createBuild(request);
-      }, expectedError);
+      await assert.rejects(client.createBuild(request), expectedError);
       assert(
         (client.innerApiCalls.createBuild as SinonStub)
           .getCall(0)
@@ -1509,14 +1485,50 @@ describe('v1.CloudBuildClient', () => {
         expectedError
       );
       const [operation] = await client.createBuild(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.createBuild as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkCreateBuildProgress without error', async () => {
+      const client = new cloudbuildModule.v1.CloudBuildClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkCreateBuildProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkCreateBuildProgress with error', async () => {
+      const client = new cloudbuildModule.v1.CloudBuildClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkCreateBuildProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1631,9 +1643,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.retryBuild(request);
-      }, expectedError);
+      await assert.rejects(client.retryBuild(request), expectedError);
       assert(
         (client.innerApiCalls.retryBuild as SinonStub)
           .getCall(0)
@@ -1666,14 +1676,50 @@ describe('v1.CloudBuildClient', () => {
         expectedError
       );
       const [operation] = await client.retryBuild(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.retryBuild as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkRetryBuildProgress without error', async () => {
+      const client = new cloudbuildModule.v1.CloudBuildClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkRetryBuildProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkRetryBuildProgress with error', async () => {
+      const client = new cloudbuildModule.v1.CloudBuildClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkRetryBuildProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1790,9 +1836,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.runBuildTrigger(request);
-      }, expectedError);
+      await assert.rejects(client.runBuildTrigger(request), expectedError);
       assert(
         (client.innerApiCalls.runBuildTrigger as SinonStub)
           .getCall(0)
@@ -1825,14 +1869,53 @@ describe('v1.CloudBuildClient', () => {
         expectedError
       );
       const [operation] = await client.runBuildTrigger(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.runBuildTrigger as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkRunBuildTriggerProgress without error', async () => {
+      const client = new cloudbuildModule.v1.CloudBuildClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkRunBuildTriggerProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkRunBuildTriggerProgress with error', async () => {
+      const client = new cloudbuildModule.v1.CloudBuildClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkRunBuildTriggerProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1943,9 +2026,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listBuilds(request);
-      }, expectedError);
+      await assert.rejects(client.listBuilds(request), expectedError);
       assert(
         (client.innerApiCalls.listBuilds as SinonStub)
           .getCall(0)
@@ -2035,9 +2116,7 @@ describe('v1.CloudBuildClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listBuilds.createStream as SinonStub)
           .getCall(0)
@@ -2247,9 +2326,7 @@ describe('v1.CloudBuildClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listBuildTriggers(request);
-      }, expectedError);
+      await assert.rejects(client.listBuildTriggers(request), expectedError);
       assert(
         (client.innerApiCalls.listBuildTriggers as SinonStub)
           .getCall(0)
@@ -2346,9 +2423,7 @@ describe('v1.CloudBuildClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listBuildTriggers.createStream as SinonStub)
           .getCall(0)


### PR DESCRIPTION
For each client method returning a long running operation, a separate method to check its status is added.

Added methods: `checkCreateBuildProgress`, `checkRetryBuildProgress`, `checkRunBuildTriggerProgress`.