### PR TITLE
chore(quickstart): mention private pool caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ async function quickstart(
   const {CloudBuildClient} = require('@google-cloud/cloudbuild');
 
   // Creates a client
+  // Note: for Private Pools, you'll have to specify an API endpoint value
+  // For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
   const cb = new CloudBuildClient();
 
   // Starts a build against the branch provided.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ async function quickstart(
   const {CloudBuildClient} = require('@google-cloud/cloudbuild');
 
   // Creates a client
-  // Note: for Private Pools, you'll have to specify an API endpoint value
-  // For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
   const cb = new CloudBuildClient();
+
+  // Note: for Private Pools, you'll have to specify an API endpoint value
+  // For example:
+  // const cb = new CloudBuildClient({ apiEndpoint: '<YOUR_POOL_REGION>-cloudbuild.googleapis.com' });
 
   // Starts a build against the branch provided.
   const [resp] = await cb.runBuildTrigger({

--- a/README.md
+++ b/README.md
@@ -66,11 +66,9 @@ async function quickstart(
   const {CloudBuildClient} = require('@google-cloud/cloudbuild');
 
   // Creates a client
-  const cb = new CloudBuildClient();
-  
   // Note: for Private Pools, you'll have to specify an API endpoint value
-  // For example:
-  // const cb = new CloudBuildClient({ apiEndpoint: '<YOUR_POOL_REGION>-cloudbuild.googleapis.com' });
+  // For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
+  const cb = new CloudBuildClient();
 
   // Starts a build against the branch provided.
   const [resp] = await cb.runBuildTrigger({

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ async function quickstart(
   const {CloudBuildClient} = require('@google-cloud/cloudbuild');
 
   // Creates a client
-  // Note: for Private Pools, you'll have to specify an API endpoint value
-  // For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
   const cb = new CloudBuildClient();
+  
+  // Note: for Private Pools, you'll have to specify an API endpoint value
+  // For example:
+  // const cb = new CloudBuildClient({ apiEndpoint: '<YOUR_POOL_REGION>-cloudbuild.googleapis.com' });
 
   // Starts a build against the branch provided.
   const [resp] = await cb.runBuildTrigger({

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -25,6 +25,8 @@ async function quickstart(
   const {CloudBuildClient} = require('@google-cloud/cloudbuild');
 
   // Creates a client
+  // Note: for Private Pools, you'll have to specify an API endpoint value
+  // For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
   const cb = new CloudBuildClient();
 
   // Starts a build against the branch provided.

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -25,9 +25,11 @@ async function quickstart(
   const {CloudBuildClient} = require('@google-cloud/cloudbuild');
 
   // Creates a client
-  // Note: for Private Pools, you'll have to specify an API endpoint value
-  // For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
   const cb = new CloudBuildClient();
+    
+  // Note: for Private Pools, you'll have to specify an API endpoint value
+  // For example:
+  // const cb = new CloudBuildClient({ apiEndpoint: '<YOUR_POOL_REGION>-cloudbuild.googleapis.com' });
 
   // Starts a build against the branch provided.
   const [resp] = await cb.runBuildTrigger({

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -26,7 +26,7 @@ async function quickstart(
 
   // Creates a client
   const cb = new CloudBuildClient();
-    
+
   // Note: for Private Pools, you'll have to specify an API endpoint value
   // For example:
   // const cb = new CloudBuildClient({ apiEndpoint: '<YOUR_POOL_REGION>-cloudbuild.googleapis.com' });


### PR DESCRIPTION
Fixes #300

@bcoe I'm assuming this quickstart is generated. If so, can we propagate this change **in the generation layer itself?**